### PR TITLE
Fix finalizeSpawn being called before moveTo

### DIFF
--- a/common/src/main/java/dev/hexnowloading/dungeonnowloading/world/features/entities/SkeletonCaveSpiderJokeyFeature.java
+++ b/common/src/main/java/dev/hexnowloading/dungeonnowloading/world/features/entities/SkeletonCaveSpiderJokeyFeature.java
@@ -23,9 +23,9 @@ public class SkeletonCaveSpiderJokeyFeature extends Feature<NoneFeatureConfigura
 
         Skeleton skeleton = EntityType.SKELETON.create(context.level().getLevel());
         skeleton.setPersistenceRequired();
+        skeleton.moveTo((double)context.origin().getX() + 0.5D, context.origin().getY() + 1, (double)context.origin().getZ() + 0.5D, 0.0F, 0.0F);
         skeleton.finalizeSpawn(context.level(), context.level().getCurrentDifficultyAt(context.origin()), MobSpawnType.STRUCTURE, null, null);
         EntityScale.scaleMobAttributes(skeleton);
-        skeleton.moveTo((double)context.origin().getX() + 0.5D, context.origin().getY() + 1, (double)context.origin().getZ() + 0.5D, 0.0F, 0.0F);
 
         skeleton.startRiding(caveSpider);
 

--- a/common/src/main/java/dev/hexnowloading/dungeonnowloading/world/features/entities/SkeletonSpiderJokeyFeature.java
+++ b/common/src/main/java/dev/hexnowloading/dungeonnowloading/world/features/entities/SkeletonSpiderJokeyFeature.java
@@ -23,10 +23,10 @@ public class SkeletonSpiderJokeyFeature extends Feature<NoneFeatureConfiguration
         EntityScale.scaleMobAttributes(spider);
 
         Skeleton skeleton = EntityType.SKELETON.create(context.level().getLevel());
-        skeleton.finalizeSpawn(context.level(), context.level().getCurrentDifficultyAt(context.origin()), MobSpawnType.STRUCTURE, null, null);
         skeleton.setPersistenceRequired();
-        EntityScale.scaleMobAttributes(skeleton);
         skeleton.moveTo((double)context.origin().getX() + 0.5D, context.origin().getY() + 1, (double)context.origin().getZ() + 0.5D, 0.0F, 0.0F);
+        skeleton.finalizeSpawn(context.level(), context.level().getCurrentDifficultyAt(context.origin()), MobSpawnType.STRUCTURE, null, null);
+        EntityScale.scaleMobAttributes(skeleton);
 
         skeleton.startRiding(spider);
 


### PR DESCRIPTION
Skeletons being spawned within the spider jockey features are being marked with finalizeSpawn before being moved to their locations, which causes an out of bound error for mods that try to get the chunk at the mobs location.